### PR TITLE
server [wip]

### DIFF
--- a/server/node/server.js
+++ b/server/node/server.js
@@ -35,7 +35,9 @@ app.get("/public-key", (req, res) => {
 });
 
 app.post("/create-setup-intent", async (req, res) => {
-  res.send(await stripe.setupIntents.create());
+  res.send(await stripe.setupIntents.create({
+    use_stripe_sdk: true
+  }));
 });
 
 // Webhook handler for asynchronous events.


### PR DESCRIPTION
Not sure if we need `use_stripe_sdk` for this...

## Testing
curl -d '{"currency":"usd","items":["foo"]}' http://localhost:4242/create-payment-intent -H "Content-Type: application/json" -X POST

- [ ] java
- [ ] node
- [ ] php
- [ ] python
- [ ] ruby